### PR TITLE
add auto-creating assemblies using webpack if using the git version, fix non-writeable log dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,17 @@ This repo sets up a test environment to test simplesamlphp. It creates four serv
 
 all available in your browser. proxy and sp1 is setup to use idp as idp, while sp2 uses proxy as idp.
 
-To get started put the version of simplesamlphp you want to test in a
-folder named `simplesamlphp`. Then run `docker-compose up -d`. The
+To get started put the release version of simplesamlphp you want to test in a
+folder named `simplesamlphp`. You also could clone the recent master branch
+into this folder using the following command:
+
+    git clone https://github.com/simplesamlphp/simplesamlphp
+
+Then run `docker-compose up -d`. The
 `ca` folder should now contain a `ca.pem` file you can import in your
 browser to https access. Then point your browser at
 https://sp1.tutorial.stack-dev.cirrusidentity.com or
 https://sp2.tutorial.stack-dev.cirrusidentity.com to start testing.
+
+Make sure that all DNS entries are set up correctly if you are
+running `docker` on another machine, e.g. within a separate VM.

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libmemcached-dev \
   libpng-dev \
   unzip \
+  nodejs \
+  npm \
   zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-install -j5 gd mbstring mysqli pdo pdo_mysql \

--- a/build/startup.sh
+++ b/build/startup.sh
@@ -2,7 +2,7 @@
 test -d vendor || composer install --no-dev
 if [ ! -f "www/assets/js/bundle.js" ]
 then
-  test -d node_modules || npm install
+  npm install
   npm run build
 fi
 exec "$@"

--- a/build/startup.sh
+++ b/build/startup.sh
@@ -1,3 +1,5 @@
 #! /bin/sh
 test -d vendor || composer install --no-dev
+test -d node_modules || npm install
+test -f www/assets/js/bundle.js || npm run build
 exec "$@"

--- a/build/startup.sh
+++ b/build/startup.sh
@@ -1,5 +1,8 @@
 #! /bin/sh
 test -d vendor || composer install --no-dev
-test -d node_modules || npm install
-test -f www/assets/js/bundle.js || npm run build
+if [ ! -f "www/assets/js/bundle.js" ]
+then
+  test -d node_modules || npm install
+  npm run build
+fi
 exec "$@"

--- a/proxy/config.php
+++ b/proxy/config.php
@@ -42,7 +42,7 @@ $config = array(
      * root directory.
      */
     'certdir' => 'cert/',
-    'loggingdir' => 'log/',
+    'loggingdir' => '/tmp/simplesaml',
     'datadir' => 'data/',
     'tempdir' => '/tmp/simplesaml',
 

--- a/sp1/config.php
+++ b/sp1/config.php
@@ -42,7 +42,7 @@ $config = array(
      * root directory.
      */
     'certdir' => 'cert/',
-    'loggingdir' => 'log/',
+    'loggingdir' => '/tmp/simplesaml',
     'datadir' => 'data/',
     'tempdir' => '/tmp/simplesaml',
 

--- a/sp2/config.php
+++ b/sp2/config.php
@@ -42,7 +42,7 @@ $config = array(
      * root directory.
      */
     'certdir' => 'cert/',
-    'loggingdir' => 'log/',
+    'loggingdir' => '/tmp/simplesaml',
     'datadir' => 'data/',
     'tempdir' => '/tmp/simplesaml',
 


### PR DESCRIPTION
I noted that the dependencies for php are installed via composer, but there is no building of the assets included if using a version directly from the git repo.

addionally, SP1 crashed throwing a Symfony exception as the log directory was not writeable. I changed the sp1, sp2 and proxy config.php to use the temp folder for logs